### PR TITLE
Integrate Pidgin with org-pomodoro

### DIFF
--- a/org-pomodoro-pidgin.el
+++ b/org-pomodoro-pidgin.el
@@ -72,14 +72,16 @@ https://developer.pidgin.im/wiki/DbusHowto#CallingPidginmethods."
   "Call METHOD with D-Bus and execute HANDLER upon answer.
 
 ARGS lists additional parameters for METHOD."
-  (apply #'dbus-call-method-asynchronously
-   :session
-   "im.pidgin.purple.PurpleService"
-   "/im/pidgin/purple/PurpleObject"
-   "im.pidgin.purple.PurpleInterface"
-   method
-   handler
-   args))
+  (when
+      (member "im.pidgin.purple.PurpleService" (dbus-list-known-names :session))
+    (apply #'dbus-call-method-asynchronously
+         :session
+         "im.pidgin.purple.PurpleService"
+         "/im/pidgin/purple/PurpleObject"
+         "im.pidgin.purple.PurpleInterface"
+         method
+         handler
+         args)))
 
 (defun org-pompid--set-status-message (status message)
   "Update STATUS with the MESSAGE."


### PR DESCRIPTION
Pidgin is an instant messaging program (http://pidgin.im). When a
pomodoro starts, the status message in Pidgin will reflect the
unavailability of the user and will show the time at which the
pomodoro ends. Upon completion of the pomodoro, the status of the user will change to Available.

Signed-off-by: Damien Cassou damien.cassou@gmail.com
