### PR TITLE
One Bug Fix and One "Feature"

### DIFF
--- a/org-pomodoro.el
+++ b/org-pomodoro.el
@@ -292,6 +292,7 @@ This may send a notification and play a sound."
 ;; ---------------------------------------
 ;; The actual function to handle pomodoros
 ;; ---------------------------------------
+;;;###autoload
 (defun org-pomodoro ()
   "Start a new pomodoro or stop the current one.
 When no timer is running for `org-pomodoro` a new pomodoro is started and


### PR DESCRIPTION
Hi there.

I notice that when you go to interrupt a break timer early, `org-pomodoro-kill` attempts to cancel the currently running clock even when no clock is running.  So one commit tests for `org-clocking-p`.

Also, for those of us snagging this code via MELPA, the "autoload" cookie is convenient.  One less `require' in my .emacs!

Thanks for the code, it's just what I'm looking for!

Trev
