### PR TITLE
Require 'org-clock

### DIFF
--- a/org-pomodoro.el
+++ b/org-pomodoro.el
@@ -35,6 +35,7 @@
 
 (require 'timer)
 (require 'org)
+(require 'org-clock)
 (require 'org-timer)
 (require 'alert)
 


### PR DESCRIPTION
This is needed for 'org-clocking-p, as introduced in #3.

The commit therefore avoids the byte-compilation warning:

```
org-pomodoro.el:330:1:Warning: the function `org-clocking-p' is not known to be defined.
```

There's also `org-clock-is-active` in `org.el`, which sounds like it should give the same results, but its implementation is different. You might prefer to use that instead, if it turns out to do the same thing.
