### PR TITLE
Add `org-agenda` to required packages

### DIFF
--- a/org-pomodoro.el
+++ b/org-pomodoro.el
@@ -32,13 +32,15 @@
 ;;   http://www.pomodorotechnique.com
 
 ;;; Code:
+(eval-when-compile
+  (require 'cl-lib))
 
 (require 'timer)
 (require 'org)
+(require 'org-agenda)
 (require 'org-clock)
 (require 'org-timer)
 (require 'alert)
-(require 'cl-lib)
 
 ;;; Custom Variables
 


### PR DESCRIPTION
Becuase`org-agenda-buffer-name` is a void variable.