### PR TITLE
Added tick-sound period variable

### DIFF
--- a/org-pomodoro.el
+++ b/org-pomodoro.el
@@ -206,6 +206,11 @@ Use `org-pomodoro-long-break-sound' to determine what sound that should be."
   :group 'org-pomodoro
   :type 'file)
 
+(defcustom org-pomodoro-tick-period 1
+  "How often to play the tick sound in seconds."
+  :group 'org-pomodoro
+  :type 'integer)
+
 (defcustom org-pomodoro-ticking-sound-args nil
   "Arguments used when playing the `org-pomodoro-ticking-sound'."
   :group 'org-pomodoro
@@ -426,11 +431,11 @@ invokes the handlers for finishing."
   "Set the org-pomodoro STATE."
   (setq org-pomodoro-state state
         org-pomodoro-countdown
-          (cl-case state
-            (:pomodoro (* 60 org-pomodoro-length))
-            (:short-break (* 60 org-pomodoro-short-break-length))
-            (:long-break (* 60 org-pomodoro-long-break-length)))
-        org-pomodoro-timer (run-with-timer t 1 'org-pomodoro-tick)))
+        (cl-case state
+          (:pomodoro (* 60 org-pomodoro-length))
+          (:short-break (* 60 org-pomodoro-short-break-length))
+          (:long-break (* 60 org-pomodoro-long-break-length)))
+        org-pomodoro-timer (run-with-timer t org-pomodoro-tick-period 'org-pomodoro-tick)))
 
 (defun org-pomodoro-start (&optional state)
   "Start the `org-pomodoro` timer.


### PR DESCRIPTION
User can adjust how often the "tick" sound is played.
Default is org-pomodoro-tick-period 1: which is the current behavior: tick every second.

Setting e.g. org-pomodoro-tick-period to 5, will play the tick sound only every 5 second.

The change was implemented because ticking is an excellent feature, but every second was a bit too excessive to me. This way you can adjust how often you get the "pulse".