### PR TITLE
Blank the mode-line string when `org-pomodoro-format` is empty

### DIFF
--- a/org-pomodoro.el
+++ b/org-pomodoro.el
@@ -401,7 +401,7 @@ or :break when starting a break.")
               (propertize org-pomodoro-long-break-format
                           'face 'org-pomodoro-mode-line-break)))))
     (setq org-pomodoro-mode-line
-          (when (org-pomodoro-active-p)
+          (when (and (org-pomodoro-active-p) (> (length s) 0))
             (list "[" (format s (org-pomodoro-format-seconds)) "] "))))
   (force-mode-line-update t))
 


### PR DESCRIPTION
At the moment, I don't think that there's a way to avoid anything being displayed in the mode-line. This is a shame if you're using the provided hooks to update an external status bar, in which case the information on the mode-line is redundant.
