### PR TITLE
Add org-pomodoro-before-start-hook.

### DIFF
--- a/org-pomodoro.el
+++ b/org-pomodoro.el
@@ -257,6 +257,8 @@ whether to reset the pomodoro count next time you call `org-pomodoro'."
   :type 'boolean)
 
 ;; Hooks
+(defvar org-pomodoro-before-start-hook nil
+  "Hooks run before a pomodoro is started.")
 
 (defvar org-pomodoro-started-hook nil
   "Hooks run when a pomodoro is started.")
@@ -456,6 +458,8 @@ The argument STATE is optional.  The default state is `:pomodoro`."
   (unless (memq 'org-pomodoro-mode-line global-mode-string)
     (setq global-mode-string (append global-mode-string
                                      '(org-pomodoro-mode-line))))
+
+  (run-hooks 'org-pomodoro-before-start-hook)
 
   (org-pomodoro-set (or state :pomodoro))
 


### PR DESCRIPTION
Additional hook that runs right before org-pomodoro-set allows one, for example, to do dynamic customization of org-pomodoro-length based on effort estimate rather than using a static org-pomodoro-length. I am developing another package that uses org-pomodoro as a dependency, but requires this hook. I hope you'll consider accepting this pull request. org-pomdoro is great, thanks for creating it!