### PR TITLE
Add functionality to stop a running pomodoro timer only on demand.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This adds very basic support for
 [Pomodoro technique](http://www.pomodorotechnique.com/)
 in Emacs' org-mode.
 
-With default customs:
+With default options:
 
 You can start a pomodoro for the task at point or select one of the
 last tasks that you clocked time for. Each clocked-in pomodoro
@@ -38,6 +38,24 @@ Usage
     a pomodoro.
  4. If you call `org-pomodoro` outside org-mode, you'll be presented
     with list of recent tasks, as `C-u org-clock-in` would.
+
+Customization
+=============
+
+Most aspects of `org-pomodoro` can be customized. Examples are the
+length of pomodoros and breaks (`org-pomodoro-length`,
+`org-pomodoro-short-break-length`, `org-pomodoro-long-break-length`),
+sounds, modeline display, if breaks should be clocked
+(`org-pomodoro-clock-break`) the behaviour when a pomodoro is reset
+(`org-pomodoro-ask-upon-killing`, `org-pomodoro-keep-killed-time`)
+etc. Have a look at the `org-pomodoro` customization group.
+
+Some workflows benefit from the option to work a few minutes
+“overtime” to finish a task before taking a break (that is, a slightly
+dynamic pomodoro time). The option `org-pomodoro-manual-break` enables
+this workflow, where a break notification is sent at the end of the
+pomodoro time but the break is started first when manually calling
+`org-pomodoro`.
 
 License
 =======


### PR DESCRIPTION
Sometimes, you don’t want to break your flow exactly after 25 minutes and just have to complete a sentence/paragraph (I mostly write) or function or whatever. For this reason, I find it valuable to be able to stretch a pomodoro a little bit extra instead of instantly taking my hands of the keyboard (and automatically clock out the org task) when org-pomodoro signals that it’s time for a break (in this workflow I’m not clocking break time).

These changes allows this workflow. I’m not sure if it’s the best way of implementing this but it seems fairly clean to me and has worked for me for the last few days.
With the new option `org-pomodoro-manual-break` (is there a better name?) set to non-nil, when the time for a pomodoro runs up, we enter an "overtime" state, indicated on the modeline (by default) with a + sign.

![org-pomodoro-overtime](https://user-images.githubusercontent.com/846411/58474263-ea4d2c80-814a-11e9-8dbb-169cf39248ae.png)

The next invocation of org-pomodoro calls the ordinary org-pomodoro-finished function to clock-out, enter breaks, etc.

Feel free to pull, discard or suggest any changes in the implementation as you see fit!